### PR TITLE
fix(ci): replace CodeQL with security check in release validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
             const requiredChecks = [
               'build (20)',
               'build (22)',
-              'Code scanning results / CodeQL'
+              'security'
             ];
             const failedChecks = [];
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,11 @@ jobs:
             console.log(`Found ${checks.check_runs.length} check runs`);
 
             const requiredChecks = [
+              // Node.js v20 build and test pipeline
               'build (20)',
+              // Node.js v22 build and test pipeline
               'build (22)',
+              // Security audit and vulnerability scanning
               'security'
             ];
             const failedChecks = [];


### PR DESCRIPTION
## 🔧 Fix Required Checks Configuration

### Problem
- Release workflow was checking for 'Code scanning results / CodeQL' 
- This is GitHub's automatic security scanning, not a CI pipeline
- Causing false failures in release validation

### Solution
- ✅ Replace 'Code scanning results / CodeQL' with 'security'
- ✅ Align with actual CI pipeline check names
- ✅ Ensure proper validation of security CI job

### Required Checks Now
- `build (20)` - Node.js 20 CI pipeline
- `build (22)` - Node.js 22 CI pipeline  
- `security` - Security audit CI pipeline

### Testing
- [ ] Verify workflow validates security pipeline
- [ ] Confirm release proceeds when all CI checks pass
- [ ] Test release blocking when security check fails