### PR TITLE
feat(core): add Azure Application Gateway Ingress Controller (AGIC) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,13 +501,16 @@ rutter.addAzureAGICIngress({
   cookieBasedAffinity: true,
   requestTimeout: 60,
   appgwSslCertificate: 'my-ssl-cert',
-  wafPolicyForPath: '/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.Network/applicationGatewayWebApplicationFirewallPolicies/waf-policy',
+  wafPolicyForPath:
+    '/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.Network/applicationGatewayWebApplicationFirewallPolicies/waf-policy',
 });
 
 // Advanced AGIC features
 rutter.addAzureAGICIngress({
   name: 'advanced-ingress',
-  rules: [/* rules */],
+  rules: [
+    /* rules */
+  ],
   backendPathPrefix: '/api/v1',
   backendHostname: 'internal.example.com',
   usePrivateIp: true,

--- a/README.md
+++ b/README.md
@@ -474,6 +474,53 @@ rutter.addAzureDiskStorageClass({
 });
 ```
 
+#### Azure Application Gateway Ingress Controller (AGIC)
+
+Comprehensive AGIC support for AKS deployments with advanced features:
+
+```typescript
+// AGIC Ingress with SSL and health checks
+rutter.addAzureAGICIngress({
+  name: 'app-ingress',
+  rules: [
+    {
+      host: 'app.example.com',
+      paths: [
+        {
+          path: '/',
+          pathType: 'Prefix',
+          backend: { service: { name: 'app-service', port: { number: 80 } } },
+        },
+      ],
+    },
+  ],
+  sslRedirect: true,
+  backendProtocol: 'https',
+  healthProbePath: '/health',
+  healthProbeInterval: 30,
+  cookieBasedAffinity: true,
+  requestTimeout: 60,
+  appgwSslCertificate: 'my-ssl-cert',
+  wafPolicyForPath: '/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.Network/applicationGatewayWebApplicationFirewallPolicies/waf-policy',
+});
+
+// Advanced AGIC features
+rutter.addAzureAGICIngress({
+  name: 'advanced-ingress',
+  rules: [/* rules */],
+  backendPathPrefix: '/api/v1',
+  backendHostname: 'internal.example.com',
+  usePrivateIp: true,
+  overrideFrontendPort: 8080,
+  connectionDraining: true,
+  connectionDrainingTimeout: 60,
+  hostnameExtension: ['api.example.com', 'admin.example.com'],
+  appgwTrustedRootCertificate: ['root-cert-1', 'root-cert-2'],
+  rewriteRuleSet: 'custom-rewrite-rules',
+  rulePriority: 100,
+});
+```
+
 ## Network Security with NetworkPolicies
 
 Timonel provides comprehensive NetworkPolicy helpers for implementing Zero Trust network security
@@ -736,8 +783,7 @@ Provide `envValues` in the `Rutter` constructor to automatically create
 - ✅ Auto-scaling helpers (HPA, VPA, PodDisruptionBudget)
 - ✅ AWS multi-cloud support (EBS, EFS, ALB, IRSA, Secrets Manager, Parameter Store)
 - ✅ Custom manifest naming and file organization
-- ✅ Azure multi-cloud support (Azure Disk StorageClass)
-- Azure Application Gateway Ingress Controller (AGIC)
+- ✅ Azure multi-cloud support (Azure Disk StorageClass, AGIC)
 - GCP multi-cloud support (GKE-specific helpers)
 - Richer CLI (resource generators, diff)
 - Template validation and testing utilities


### PR DESCRIPTION
# Pull Request

## Description

This PR adds comprehensive support for Azure Application Gateway Ingress Controller (AGIC) to Timonel, enabling AKS deployments with advanced ingress capabilities.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Changes Made

- Add comprehensive  interface with all AGIC annotations support
- Implement  method with full feature coverage
- Support for SSL redirect, backend protocol configuration, and custom health probes
- Include advanced features like hostname extension, WAF policies, and connection draining
- Add comprehensive JSDoc documentation with practical examples
- Update README with detailed AGIC usage examples and mark feature as completed in roadmap

## Testing

- [x] Tests pass locally with `pnpm ci:check`
- [x] Manual testing completed with test script
- [x] All linting, type checking, and security audits pass
- [x] Example integration verified

## Documentation

- [x] README updated with comprehensive AGIC examples
- [x] JSDoc comments added with detailed parameter descriptions
- [x] Roadmap updated to reflect completion

## Security

- [x] No sensitive information exposed
- [x] Security implications considered (WAF policy support included)
- [x] Dependencies reviewed for vulnerabilities

## Breaking Changes



## Additional Notes

This implementation provides complete AGIC annotation support including:
- Path and hostname configuration
- SSL/TLS termination and redirect
- Health probe customization
- Connection management (draining, affinity, timeouts)
- Security features (WAF policies, trusted certificates)
- Advanced routing (rewrite rules, rule priorities)

The implementation follows the same patterns as existing AWS ALB Ingress support for consistency.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Code is properly commented
- [x] Corresponding changes to documentation made
- [x] No new warnings introduced
- [x] All CI checks pass