### PR TITLE
fix(core): resolve Helm template literal bug in rutter.ts

### DIFF
--- a/src/lib/rutter.ts
+++ b/src/lib/rutter.ts
@@ -4,7 +4,6 @@ import type { Ingress, ServiceAccount } from 'cdk8s-plus-33';
 import type { Construct } from 'constructs';
 import * as jsYaml from 'js-yaml';
 
-import { include } from './helm.js';
 import { HelmChartWriter, type SynthAsset } from './helmChartWriter.js';
 import { dumpHelmAwareYaml } from './utils/helmYamlSerializer.js';
 import { AWSResources } from './resources/cloud/aws/awsResources.js';
@@ -674,9 +673,14 @@ ${yamlContent.trim()}
         o.metadata = o.metadata ?? {};
         o.metadata.labels = o.metadata.labels ?? {};
         const labels = o.metadata.labels as Record<string, unknown>;
+        /**
+         * Default Kubernetes labels following Helm best practices
+         * Fixed template literal bug: using proper Helm syntax instead of JavaScript template evaluation
+         * @since 2.9.3
+         */
         const defaults: Record<string, string> = {
           'helm.sh/chart': `{{ .Chart.Name }}-{{ .Chart.Version }}`,
-          'app.kubernetes.io/name': `{{ ${include} "${Rutter.HELPER_NAME}" . }}`,
+          'app.kubernetes.io/name': `{{ include "${Rutter.HELPER_NAME}" . }}`,
           'app.kubernetes.io/instance': '{{ .Release.Name }}',
           'app.kubernetes.io/version': '{{ .Chart.Version }}',
           'app.kubernetes.io/managed-by': '{{ .Release.Service }}',


### PR DESCRIPTION
## 🐛 Bug Fix

### Problema
Se identificó un bug en la línea 679 de  donde se usaba incorrectamente un template literal de JavaScript () dentro de una plantilla de Helm, causando problemas en la generación de charts.

### Solución
- ✅ Corregido el uso incorrecto de template literal en  label
- ✅ Removida importación no utilizada de  desde 
- ✅ Agregados comentarios JSDoc explicativos con 
- ✅ Todas las validaciones de linters y seguridad pasan
- ✅ Validación de Helm lint exitosa

### Cambios Realizados
1. **Línea 679**: Cambio de  a  para usar sintaxis correcta de Helm
2. **Importaciones**: Removida importación no utilizada de 
3. **Documentación**: Agregados comentarios JSDoc explicando el fix

### Validaciones
- [x] ESLint
- [x] Prettier
- [x] TypeScript type check
- [x] Security audit
- [x] Security lint
- [x] Helm lint en charts generados
- [x] Tests de integración

### Tipo de Cambio
- [x] Bug fix (cambio que no rompe funcionalidad y corrige un issue)

Fixes template literal syntax que causaba problemas en la generación de charts de Helm.